### PR TITLE
fix: missing url search when request auto redirect

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -584,7 +584,7 @@ module.exports = async (request, response, config = {}, methods = {}) => {
 
 	if (redirect) {
 		response.writeHead(redirect.statusCode, {
-			Location: encodeURI(redirect.target)
+			Location: encodeURI(redirect.target + (url.parse(request.url).search || ''))
 		});
 
 		response.end();


### PR DESCRIPTION
serve-handler will trim the ending `.html` suffix from url.pathname and make a redirect but forgot take the `search`, it may cause errors sometimes.
