### PR TITLE
Don't encode URLs in rewrites/redirects

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -85,7 +85,7 @@ const toTarget = (source, destination, previousPath) => {
 		props[name] = results[index + 1];
 	}
 
-	return toPath(props);
+	return toPath(props, { encode: _ => _ });
 };
 
 const applyRewrites = (requestPath, rewrites = [], repetitive) => {


### PR DESCRIPTION
Was trying to do something similar to what #27 describes, and found that although `pathToRegExp.compile()` supports `/:path(.+)` to insert the rest of a path including `/` characters, when `toPath()` is called to convert the props back into the rewritten or redirected path, the `encode` option is not specified, which causes the default `encodeURIComponent` to be used.

In v5.0.0 `path-to-regexp` uses the identity function by default instead, which is what it should have done from the beginning. If you specify a `source` of `/some/path/:path+` and a `destination` of `/:path(.+)`, you don't want to rewrite `/some/path/a/b/c` to `/a%2Fb%2Fc`. You would want simply `/a/b/c`.