### PR TITLE
chore: replace deprecated String.prototype.substr()

### DIFF
--- a/src/glob-slash.js
+++ b/src/glob-slash.js
@@ -5,5 +5,5 @@
 const path = require('path');
 const normalize = value => path.posix.normalize(path.posix.join('/', value));
 
-module.exports = value => (value.charAt(0) === '!' ? `!${normalize(value.substr(1))}` : normalize(value));
+module.exports = value => (value.charAt(0) === '!' ? `!${normalize(value.slice(1))}` : normalize(value));
 module.exports.normalize = normalize;

--- a/test/integration.js
+++ b/test/integration.js
@@ -1196,7 +1196,7 @@ test('range request', async t => {
 	t.is(response.status, 206);
 
 	const text = await response.text();
-	const spec = content.toString().substr(0, 11);
+	const spec = content.toString().slice(0, 11);
 
 	t.is(text, spec);
 });


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.