### PR TITLE
Fix publish action

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,7 +3,7 @@ name: Publish Package
 on:
   workflow_dispatch:
   release:
-      types: [published]
+    types: [published]
 
 jobs:
   build:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,8 +1,9 @@
 name: Publish Package
 
 on:
+  workflow_dispatch:
   release:
-    types: [created]
+      types: [published]
 
 jobs:
   build:


### PR DESCRIPTION
We need to use `published` instead of `created` since drafts will never get into the `created` state.

Also added `workflow_dispatch` to manually run it again.

See the docs https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release