### PR TITLE
Ensure `npm run prepublish` gets executed

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -14,8 +14,11 @@ jobs:
         timeout-minutes: 5 # See https://github.com/actions/cache/issues/810
         with:
           cache: 'yarn'
+          node-version: '16.x'
+          registry-url: 'https://registry.npmjs.org'
 
       - run: yarn install --network-timeout 1000000 --frozen-lockfile
+      - run: npm run test
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_ELEVATED }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -14,7 +14,6 @@ jobs:
         with:
           node-version: '16.x'
           registry-url: 'https://registry.npmjs.org'
-      - run: npm run prepublish
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_ELEVATED }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -14,6 +14,7 @@ jobs:
         with:
           node-version: '16.x'
           registry-url: 'https://registry.npmjs.org'
+      - run: npm run prepublish
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_ELEVATED }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -11,9 +11,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
+        timeout-minutes: 5 # See https://github.com/actions/cache/issues/810
         with:
-          node-version: '16.x'
-          registry-url: 'https://registry.npmjs.org'
+          cache: 'yarn'
+
+      - run: yarn install --network-timeout 1000000 --frozen-lockfile
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_ELEVATED }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -20,6 +20,7 @@ jobs:
           cache: 'yarn'
 
       - run: yarn install --network-timeout 1000000 --frozen-lockfile
+      - run: yarn run build-views
       - run: yarn test
       - run: yarn run coverage
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "coverage": "nyc report --reporter=text-lcov > coverage.lcov",
     "lint-staged": "git diff --diff-filter=ACMRT --cached --name-only '*.js' '*.jsx' | xargs zeit-eslint",
     "build-views": "dottojs -s ./src -d ./src",
-    "prepublish": "yarn run build-views"
+    "prepublishOnly": "yarn run build-views"
   },
   "repository": "zeit/serve-handler",
   "keywords": [


### PR DESCRIPTION
I've forgot to include `npm run prepublish` in the publish action.

Due to this mistake, some files were not included in the 6.1.4 release.