### PR TITLE
Add Tests Badge back to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # serve-handler
 
+[![Tests](https://github.com/vercel/serve-handler/actions/workflows/tests.yaml/badge.svg)](https://github.com/vercel/serve-handler/actions/workflows/tests.yaml)
 [![codecov](https://codecov.io/gh/vercel/serve-handler/branch/main/graph/badge.svg)](https://codecov.io/gh/vercel/serve-handler)
 [![install size](https://packagephobia.now.sh/badge?p=serve-handler)](https://packagephobia.now.sh/result?p=serve-handler)
 


### PR DESCRIPTION
Removed the CircleCI badge earlier when moving to GitHub Actions.
This PR adds an updated badge.