### PR TITLE
fix a crash due to bad symlinks

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -697,7 +697,19 @@ module.exports = async (request, response, config = {}, methods = {}) => {
 	// resolve the symlink and run a new `stat` call just for the
 	// target of that symlink.
 	if (isSymLink) {
-		absolutePath = await handlers.realpath(absolutePath);
+		try {
+			absolutePath = await handlers.realpath(absolutePath);
+		} catch (err) {
+			if (err.code !== 'ENOENT') {
+				throw err;
+			}
+			// The requested symlink is invalid
+			return handlers.sendError(absolutePath, response, acceptsJSON, current, handlers, config, {
+				statusCode: 404,
+				code: 'not_found',
+				message: 'The requested path could not be found'
+			});
+		}
 		stats = await handlers.lstat(absolutePath);
 	}
 

--- a/test/fixtures/symlinks/a-bad-link
+++ b/test/fixtures/symlinks/a-bad-link
@@ -1,0 +1,1 @@
+not-a-file

--- a/test/integration.js
+++ b/test/integration.js
@@ -1356,9 +1356,7 @@ test('A bad symlink should be a 404', async t => {
 	t.is(response.status, 404);
 
 	const text = await response.text();
-	const spec = 'The requested path could not be found';
-
-	t.is(text, spec);
+	t.is(text.trim(), '<span>Not Found</span>');
 });
 
 test('etag header is set', async t => {

--- a/test/integration.js
+++ b/test/integration.js
@@ -1344,6 +1344,23 @@ test('allow symlinks by setting the option', async t => {
 	t.is(text, spec);
 });
 
+test('A bad symlink should be a 404', async t => {
+	const name = 'symlinks/a-bad-link';
+
+	const url = await getUrl({
+		symlinks: true
+	});
+
+	const response = await fetch(`${url}/${name}`);
+
+	t.is(response.status, 404);
+
+	const text = await response.text();
+	const spec = 'The requested path could not be found';
+
+	t.is(text, spec);
+});
+
 test('etag header is set', async t => {
 	const url = await getUrl({
 		renderSingle: true,


### PR DESCRIPTION
Currently if there is a dangling symlink the server crashes.

This makes dangling symlinks to return 404s