### PR TITLE
X handle has changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ await handler(request, response, undefined, {
 
 ## Author
 
-Leo Lamprecht ([@notquiteleo](https://twitter.com/notquiteleo)) - [Vercel](https://vercel.com)
+Leo Lamprecht ([@leo](https://x.com/leo)) - [Vercel](https://vercel.com)
 
 
 [etag]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag


### PR DESCRIPTION
Twitter was renamed to X and my X handle changed from `@notquiteleo` to `@leo`.

This change replaces the previous broken link with the new working link.