### PR TITLE
fix: urls don't encode characters

### DIFF
--- a/src/directory.jst
+++ b/src/directory.jst
@@ -142,7 +142,7 @@
           <i>Index of&nbsp;</i>
 
           {{~it.paths :value:index}}
-            <a href="/{{!value.url}}">{{!value.name}}</a>
+            <a href="/{{!encodeURIComponent(value.url)}}">{{!value.name}}</a>
           {{~}}
         </h1>
       </header>
@@ -150,7 +150,7 @@
       <ul id="files">
         {{~it.files :value:index}}
           <li>
-            <a href="{{!value.relative}}" title="{{!value.title}}" class="{{!value.type}} {{!value.ext}}">{{!value.base}}</a>
+            <a href="{{!encodeURIComponent(value.relative)}}" title="{{!value.title}}" class="{{!value.type}} {{!value.ext}}">{{!value.base}}</a>
           </li>
         {{~}}
       </ul>


### PR DESCRIPTION
When a file url has certain symbols like number sign (#), it doesn't encode them, which makes the browser fail to navigate to the file, thinking it is a document section. This commit fixes that by encoding urls using the built-in encodeURIComponent function.

Fixes #205, vercel/serve#726, and vercel/serve#774
