### PR TITLE
Bump `path-to-regexp` to `3.3.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "mime-types": "2.1.18",
     "minimatch": "3.1.2",
     "path-is-inside": "1.0.2",
-    "path-to-regexp": "2.2.1",
+    "path-to-regexp": "3.3.0",
     "range-parser": "1.2.0"
   },
   "packageManager": "yarn@1.22.19+sha1.4ba7fc5c6e704fce2066ecbfb0b0d8976fe62447"

--- a/src/glob-slash.js
+++ b/src/glob-slash.js
@@ -2,7 +2,7 @@
 
 // This is adopted from https://github.com/scottcorgan/glob-slash/
 
-const path = require('node:path');
+const path = require('path');
 const normalize = value => path.posix.normalize(path.posix.join('/', value));
 
 module.exports = value => (value.charAt(0) === '!' ? `!${normalize(value.substr(1))}` : normalize(value));

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,11 @@
 // Native
-const {promisify} = require('node:util');
-const path = require('node:path');
-const {createHash} = require('node:crypto');
-const {realpath, lstat, createReadStream, readdir} = require('node:fs');
+const {promisify} = require('util');
+const path = require('path');
+const {createHash} = require('crypto');
+const {realpath, lstat, createReadStream, readdir} = require('fs');
 
 // Packages
-const url = require('node:url');
+const url = require('url');
 const slasher = require('./glob-slash');
 const minimatch = require('minimatch');
 const pathToRegExp = require('path-to-regexp');

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -1,5 +1,5 @@
 // Native
-const path = require('node:path');
+const path = require('path');
 
 // Packages
 const listen = require('test-listen');

--- a/yarn.lock
+++ b/yarn.lock
@@ -2575,10 +2575,10 @@ path-parse@^1.0.7:
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
 
-path-to-regexp@2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-2.2.1.tgz#90b617025a16381a879bc82a38d4e8bdeb2bcf45"
-  integrity sha512-gu9bD6Ta5bwGrrU8muHzVOBFFREpp2iRkVfhBJahwJ6p6Xw20SjT0MxLnwkjOibQmGSYhiUnf2FLe7k+jcFmGQ==
+path-to-regexp@3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-3.3.0.tgz#f7f31d32e8518c2660862b644414b6d5c63a611b"
+  integrity sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw==
 
 performance-now@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
Thanks to @alana-cruickshank for the original PR with those changes https://github.com/vercel/serve-handler/pull/215

Closes https://github.com/vercel/serve-handler/issues/211
Closes https://github.com/vercel/serve-handler/issues/212

Removes the `node:` I've accidentally added in https://github.com/vercel/serve-handler/pull/216