### PR TITLE
Catch path-to-regexp errors and fall through to minimatch

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -43,15 +43,22 @@ const sourceMatches = (source, requestPath, allowSegments) => {
 	let results = null;
 
 	if (allowSegments) {
-		const normalized = slashed.replace('*', '(.*)');
-		const expression = pathToRegExp(normalized, keys);
+		try {
+			const normalized = slashed.replace('*', '(.*)');
+			const expression = pathToRegExp(normalized, keys);
 
-		results = expression.exec(resolvedPath);
+			results = expression.exec(resolvedPath);
 
-		if (!results) {
-			// clear keys so that they are not used
-			// later with empty results. this may
-			// happen if minimatch returns true
+			if (!results) {
+				// clear keys so that they are not used
+				// later with empty results. this may
+				// happen if minimatch returns true
+				keys.length = 0;
+			}
+		} catch (_) {
+			// If path-to-regexp cannot parse the source pattern (e.g.
+			// extglob negation like `!(*.css|*.js)`), fall through to
+			// the minimatch check below.
 			keys.length = 0;
 		}
 	}

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -362,6 +362,25 @@ test('set `rewrites` config property to path segment', async () => {
 	expect(json).toEqual(content);
 });
 
+test('set `rewrites` config property with extglob negation pattern', async () => {
+	const destination = '.dotfile';
+	const related = path.join(fixturesFull, destination);
+	const content = await fs.readFile(related, 'utf8');
+
+	const url = await getUrl({
+		rewrites: [{
+			source: '**/!(*.js|*.css)',
+			destination
+		}]
+	});
+
+	const response = await fetch(`${url}/face/delete`);
+	const text = await response.text();
+
+	expect(response.status).toBe(200);
+	expect(text).toBe(content);
+});
+
 test('set `redirects` config property to wildcard path', async () => {
 	const destination = 'testing';
 


### PR DESCRIPTION
## Summary

The `sourceMatches` function tries `path-to-regexp` first and falls back to `minimatch` for pattern matching. However, if the source pattern uses syntax that `path-to-regexp` cannot parse (e.g. extglob negation like `**/!(*.css|*.js)`), `path-to-regexp` throws an exception instead of returning `null`. This prevents the `minimatch` fallback from ever running.

This PR wraps the `path-to-regexp` block in a try/catch so that incompatible patterns gracefully fall through to `minimatch`, which does support them.

## The problem

```javascript
// sourceMatches in src/index.js
if (allowSegments) {
    const normalized = slashed.replace('*', '(.*)');
    const expression = pathToRegExp(normalized, keys);  // throws!
    // ...
}

if (results || minimatch(resolvedPath, slashed)) {  // never reached
```

For a rewrite config like:

```json
{ "source": "**/!(*.css|*.js)", "destination": "/index.html" }
```

1. `.replace('*', '(.*)')` mangles the pattern into `(.*)*/!(*.css|*.js)`
2. `pathToRegExp` tries to compile this and throws: `Invalid regular expression: Nothing to repeat`
3. The exception propagates up — `minimatch` (which handles this pattern correctly) is never called
4. The entire `serveHandler()` promise rejects

This caused a production incident for us where the asset server silently failed to respond to any HTTP request, because the unhandled rejection meant no response was ever sent.

## The fix

Wrap lines 46-56 in a try/catch. If `path-to-regexp` throws, clear the keys array and fall through to the `minimatch` check on line 59, which is what the code already intends as a fallback.

## Tests

Added an integration test that verifies a rewrite with an extglob negation pattern works correctly (previously this would have thrown).

All 67 tests pass.

Made with [Cursor](https://cursor.com)